### PR TITLE
🐛 Don't generate doors every time you enter a room!

### DIFF
--- a/lib/degica/door.rb
+++ b/lib/degica/door.rb
@@ -26,7 +26,7 @@ module Degica
     def enter
       next_room = (@rooms - [Game.objects.actor.location])[0]
       Game.objects.actor.location = next_room
-      next_room.generate_doors!(Game.objects.rooms)
+      next_room.generate!
       next_room
     end
 

--- a/lib/degica/game.rb
+++ b/lib/degica/game.rb
@@ -1,21 +1,18 @@
 module Degica
   class Game
     def initialize
-      # setup scenes
+      # setup rooms
       rooms = RoomLoader.load
 
       # spawn actor in random room
       starting_room = rooms.sample
-      starting_room.generate_doors!(rooms)
       @actor = Actor.new(starting_room)
 
-      # preload translations for Faker
-      Faker::Name.first_name
+      # game objects
+      @@objects = OpenStruct.new(rooms: rooms, actor: @actor)
 
-      @@objects = OpenStruct.new(
-        rooms: rooms,
-        actor: @actor
-      )
+      # generate starting room
+      starting_room.generate!
     end
 
     def self.objects

--- a/lib/degica/room.rb
+++ b/lib/degica/room.rb
@@ -7,10 +7,14 @@ module Degica
       @description = description.highlight
       @doors = DoorCollection.new
       @objects = ObjectCollection.new(objects)
+      @generated = false
     end
 
-    def generate_doors!(rooms)
-      rooms = rooms.select do |room|
+    def generate!
+      return if @generated
+      @generated = true
+
+      rooms = Game.objects.rooms.select do |room|
         room.doors.empty? && room != self
       end.sample(rand(1..2))
 


### PR DESCRIPTION
Every time you entered a room it would randomly attach doors even if you had already entered the room. This is why we we're seeing 5 doors in a single room.