### PR TITLE
Join array elements into string

### DIFF
--- a/lib/degica/objects/people/person.rb
+++ b/lib/degica/objects/people/person.rb
@@ -50,7 +50,7 @@ module Degica
       desc = []
       desc << description
       desc << "Maybe you should (talk) with him.".highlight unless @talked
-      desc
+      desc.join("\n")
     end
 
     private


### PR DESCRIPTION
Otherwise, this can happen:

```
> hacker
He looks like he could hack into anything.
Maybe you should talk with him.

hacker> describe
[["He looks like he could hack into anything."], "Maybe you should \e[1;33mtalk\e[0m with him."]
```